### PR TITLE
JS action capture controller added

### DIFF
--- a/js/sapi.js
+++ b/js/sapi.js
@@ -27,7 +27,7 @@
       }, typeof options === 'object' ? options : {});
 
       $.ajax({
-        url: Drupal.url('sapi/js/send'),
+        url: Drupal.url('sapi/js/capture'),
         type: 'POST',
         data: {
           'action': action,

--- a/sapi.permissions.yml
+++ b/sapi.permissions.yml
@@ -1,0 +1,2 @@
+sapi capture js actions:
+  title: 'Capture JS actions'

--- a/sapi.routing.yml
+++ b/sapi.routing.yml
@@ -1,0 +1,8 @@
+sapi.sapi_js_capture:
+  path: 'sapi/js/capture'
+  defaults:
+    _controller: '\Drupal\sapi\Controller\SapiJsActionCaptureController::capture'
+    _title: 'JS action capture controller'
+  requirements:
+    _permission: 'sapi capture js actions'
+  methods: ['POST']

--- a/sapi.routing.yml
+++ b/sapi.routing.yml
@@ -1,7 +1,7 @@
 sapi.sapi_js_capture:
   path: 'sapi/js/capture'
   defaults:
-    _controller: '\Drupal\sapi\Controller\SapiJsActionCaptureController::capture'
+    _controller: '\Drupal\sapi\Controller\SapiJsCaptureController::capture'
     _title: 'JS action capture controller'
   requirements:
     _permission: 'sapi capture js actions'

--- a/src/Controller/SapiJsActionCaptureController.php
+++ b/src/Controller/SapiJsActionCaptureController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\sapi\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Class SapiJsActionCaptureController.
+ *
+ * @package Drupal\sapi
+ */
+class SapiJsActionCaptureController extends ControllerBase implements ContainerInjectionInterface {
+
+  /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
+  protected $requestStack;
+
+  /**
+   * SapiJsActionCaptureController constructor.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   */
+  public function __construct(RequestStack $request_stack) {
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * Captures JS action and informs the SAPI service.
+   *
+   * @return string
+   */
+  public function capture() {
+    // Get current request.
+    $request = $this->requestStack->getCurrentRequest();
+
+    // Get params.
+    $action = $request->get('action');
+    $uri = $request->get('uri');
+
+    if (!empty($action) && !empty($uri)) {
+      try {
+        // @todo Call the service.
+        return new Response('OK', 200);
+      } catch (\Exception $e) {
+        throw new HttpException(500, 'Internal Server Error', $e);
+      }
+    }
+    else {
+      throw new BadRequestHttpException('Parameter is missing.');
+    }
+  }
+
+}

--- a/src/Controller/SapiJsCaptureController.php
+++ b/src/Controller/SapiJsCaptureController.php
@@ -11,17 +11,17 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
- * Class SapiJsActionCaptureController.
+ * Class SapiJsCaptureController.
  *
  * @package Drupal\sapi
  */
-class SapiJsActionCaptureController extends ControllerBase implements ContainerInjectionInterface {
+class SapiJsCaptureController extends ControllerBase implements ContainerInjectionInterface {
 
   /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
   protected $requestStack;
 
   /**
-   * SapiJsActionCaptureController constructor.
+   * SapiJsCaptureController constructor.
    *
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    */

--- a/src/Tests/JsActionCaptureControllerTest.php
+++ b/src/Tests/JsActionCaptureControllerTest.php
@@ -80,7 +80,7 @@ class JsActionCaptureControllerTest extends WebTestBase {
    */
   public function testCaptureWithNonAuthorizedUser() {
     $this->drupalLogin($this->drupalCreateUser());
-    $this->drupalPost('sapi/js/capture', '*/*', array('action' => 'click', 'uri' => 'http://www.example.com'));
+    $this->drupalPost('sapi/js/capture', '', array('action' => 'click', 'uri' => 'http://www.example.com'));
     $this->assertResponse(403);
   }
 

--- a/src/Tests/JsActionCaptureControllerTest.php
+++ b/src/Tests/JsActionCaptureControllerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\sapi\Tests;
+
+use Drupal\simpletest\WebTestBase;
+
+/**
+ * Provides automated tests for the sapi JS action controller.
+ *
+ * @group sapi
+ */
+class JsActionCaptureControllerTest extends WebTestBase {
+
+  /**
+   * Modules to install.
+   *
+   * @var array
+   */
+  public static $modules = array('sapi');
+
+  /**
+   * A user with the 'sapi capture js actions' permission.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $webUser;
+
+  /**
+   * Path to JS action capturer.
+   *
+   * @var string $path
+   */
+  protected $path = 'sapi/js/capture';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->webUser = $this->drupalCreateUser(array('sapi capture js actions'));
+  }
+
+  /**
+   * Tests capture with empty parameters.
+   */
+  public function testCaptureWithInvalidParams() {
+    $this->drupalLogin($this->webUser);
+    $this->drupalPost($this->path, '', array());
+    $this->assertResponse(400);
+  }
+
+  /**
+   * Tests capture with missing parameters.
+   */
+  public function testCaptureWithMissingParams() {
+    $this->drupalLogin($this->webUser);
+    $this->drupalPost($this->path, '', array('action' => 'click'));
+    $this->assertResponse(400);
+  }
+
+  /**
+   * Tests a valid capture.
+   */
+  public function testValidCapture() {
+    $this->drupalLogin($this->webUser);
+    $this->drupalPost($this->path, '', array('action' => 'click', 'uri' => 'http://www.example.com'));
+    $this->assertResponse(200);
+  }
+
+  /**
+   * Tests a valid capture.
+   */
+  public function testUnreachableSapiService() {
+    // @todo Invoke controller class directly and try to fail the service call.
+    // $this->assertResponse(500, 'Response is 500 if SAPI service is not reachable.');
+  }
+
+  /**
+   * Tests capture with non-authorized user.
+   */
+  public function testCaptureWithNonAuthorizedUser() {
+    $this->drupalLogin($this->drupalCreateUser());
+    $this->drupalPost('sapi/js/capture', '*/*', array('action' => 'click', 'uri' => 'http://www.example.com'));
+    $this->assertResponse(403);
+  }
+
+}


### PR DESCRIPTION
The changes also contain test coverage. The controller doesn't do anything useful because of the missing SAPI service. It merely captures the data from SAPI JS "courier".

To validate tests run from within the docroot:
`php core/scripts/run-tests.sh --verbose --url [URL] --color --php [YOUR PHP PATH] sapi`

Trello card: https://trello.com/c/bReP4tVy
