### PR TITLE
Left over PhpDoc comment removed

### DIFF
--- a/src/Form/StatisticsPluginListForm.php
+++ b/src/Form/StatisticsPluginListForm.php
@@ -79,7 +79,7 @@ class StatisticsPluginListForm extends ConfigFormBase {
       '#default_value' => $this->config('sapi.statistics_plugins')->get('enabled'),
     ];
 
-    /** @var \Drupal\sapi\Plugin\StatisticsPluginInterface $instance */
+    // Loop through the statistics plugins.
     foreach ($this->statisticsPluginManager->getDefinitions() as $pluginDefinition) {
       $id = $pluginDefinition['id'];
       $form['plugins']['statistics_plugins'][$id]['id'] = array(


### PR DESCRIPTION
This PR removes a redundant PhpDoc comment in configuration form class.
