### PR TITLE
fixed missing namespace in dummy plugin, and fixed spelling mistake

### DIFF
--- a/src/Plugin/StatisticsPlugin/Dummy.php
+++ b/src/Plugin/StatisticsPlugin/Dummy.php
@@ -4,6 +4,7 @@ namespace Drupal\sapi\Plugin\StatisticsPlugin;
 
 use Drupal\sapi\Plugin\StatisticsPluginInterface;
 use Drupal\sapi\Plugin\StatisticsPluginBase;
+use Drupal\sapi\StatisticsItemInterface;
 
 /**
  * @StatisticsPlugin(
@@ -16,8 +17,9 @@ class Dummmy extends StatisticsPluginBase implements StatisticsPluginInterface {
   /**
    * {@inheritdoc}
    */
-  public function process(StatisticsItemIterface $item){
+  public function process(StatisticsItemInterface $item){
     $message = $item->getAction();
     \Drupal::logger('SAPI')->notice($message);
   }
+
 }

--- a/src/Plugin/StatisticsPlugin/Dummy.php
+++ b/src/Plugin/StatisticsPlugin/Dummy.php
@@ -12,7 +12,7 @@ use Drupal\sapi\StatisticsItemInterface;
  *  label = "Dummy label"
  * )
  */
-class Dummmy extends StatisticsPluginBase implements StatisticsPluginInterface {
+class Dummy extends StatisticsPluginBase implements StatisticsPluginInterface {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/StatisticsPluginInterface.php
+++ b/src/Plugin/StatisticsPluginInterface.php
@@ -3,7 +3,7 @@
 namespace Drupal\sapi\Plugin;
 
 use Drupal\Component\Plugin\PluginInspectionInterface;
-use Drupal\sapi\StatisticsItemIterface;
+use Drupal\sapi\StatisticsItemInterface;
 
 /**
  * Defines an interface for Statistics plugin plugins.
@@ -14,9 +14,9 @@ interface StatisticsPluginInterface extends PluginInspectionInterface {
    * process() method which analize and processed the data received
    * from StatisticsItemIterface
    *
-   * @param StatisticsItemIterface $item
+   * @param StatisticsItemInterface $item
    *
    */
-  public function process(StatisticsItemIterface $item);
+  public function process(StatisticsItemInterface $item);
 
 }

--- a/src/Plugin/StatisticsPluginInterface.php
+++ b/src/Plugin/StatisticsPluginInterface.php
@@ -6,16 +6,19 @@ use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\sapi\StatisticsItemInterface;
 
 /**
- * Defines an interface for Statistics plugin plugins.
+ * Interface StatisticsPluginInterface
+ *
+ * Defines an interface for plugins of type "StatisticsPlugin".
  */
 interface StatisticsPluginInterface extends PluginInspectionInterface {
 
   /**
-   * process() method which analize and processed the data received
-   * from StatisticsItemIterface
+   * Processes the statistics item and performs an arbitrary action upon it
+   * (e.g., logs, aggregates).
    *
    * @param StatisticsItemInterface $item
    *
+   * @return void
    */
   public function process(StatisticsItemInterface $item);
 


### PR DESCRIPTION
This patch fixes the missing namespace usage for StatisticsItemInteface, and fixes a spelling mistake across the dummy plugin usage.

This fixes the php error:

```
 "PHP message: PHP Fatal error:  Declaration of Drupal\sapi\Plugin\StatisticsPlugin\Dummmy::process(Drupal\sapi\Plugin\StatisticsPlugin\StatisticsItemIterface $item) must be compatible with Drupal\sapi\Plugin\StatisticsPluginInterface::process(Drupal\sapi\StatisticsItemIterface $item) in /app/web/modules/custom/sapi/src/Plugin/StatisticsPlugin/Dummy.php on line 14"
```
