### PR TITLE
Dispatcher related class renamed

### DIFF
--- a/sapi.services.yml
+++ b/sapi.services.yml
@@ -3,5 +3,5 @@ services:
     class: Drupal\sapi\Plugin\StatisticsPluginManager
     parent: default_plugin_manager
   sapi.dispatcher:
-    class: Drupal\sapi\SapiDispatcher
+    class: Drupal\sapi\Dispatcher
     arguments: ["@config.manager", "@current_user", "@current_route_match", "@plugin.manager.statisticsplugin"]

--- a/src/Controller/SapiJsCaptureController.php
+++ b/src/Controller/SapiJsCaptureController.php
@@ -4,7 +4,7 @@ namespace Drupal\sapi\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\sapi\SapiDispatcherInterface;
+use Drupal\sapi\DispatcherInterface;
 use Drupal\sapi\StatisticsItem;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -21,16 +21,16 @@ class SapiJsCaptureController extends ControllerBase implements ContainerInjecti
 
   /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
   protected $requestStack;
-  /** @var \Drupal\sapi\SapiDispatcherInterface $sapiDispatcher */
+  /** @var \Drupal\sapi\DispatcherInterface $sapiDispatcher */
   protected $sapiDispatcher;
 
   /**
    * SapiJsCaptureController constructor.
    *
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
-   * @param \Drupal\sapi\SapiDispatcherInterface $sapiDispatcher
+   * @param \Drupal\sapi\DispatcherInterface $sapiDispatcher
    */
-  public function __construct(RequestStack $requestStack, SapiDispatcherInterface $sapiDispatcher) {
+  public function __construct(RequestStack $requestStack, DispatcherInterface $sapiDispatcher) {
     $this->requestStack = $requestStack;
     $this->sapiDispatcher = $sapiDispatcher;
   }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -8,11 +8,11 @@ use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Component\Plugin\PluginManagerInterface;
 
 /**
- * Class SapiDispatcher.
+ * Class Dispatcher.
  *
  * @package Drupal\sapi
  */
-class SapiDispatcher implements SapiDispatcherInterface {
+class Dispatcher implements DispatcherInterface {
 
   /**
    * Drupal\Core\Config\ConfigManager definition.
@@ -43,7 +43,7 @@ class SapiDispatcher implements SapiDispatcherInterface {
   protected $statisticsPluginManager;
 
   /**
-   * SapiDispatcher constructor.
+   * Dispatcher constructor.
    *
    * @param \Drupal\Core\Config\ConfigManager $configManager
    * @param \Drupal\Core\Session\AccountProxy $currentUser

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -2,18 +2,16 @@
 
 namespace Drupal\sapi;
 
-use Drupal\sapi\StatisticsItemInterface;
-
 /**
- * Interface SapiDispatcherInterface.
+ * Interface DispatcherInterface.
  *
  * @package Drupal\sapi
  */
-interface SapiDispatcherInterface {
+interface DispatcherInterface {
 
    /**
     * Dispatches the statistics item to interested parties.
-    * 
+    *
     * @param StatisticsItemInterface $item
    */
   public function dispatch(StatisticsItemInterface $item);


### PR DESCRIPTION
To remove the usage of `Sapi` prefix everywhere, `SapiDispatcher` class renamed to `Dispatcher` and `SapiDispatcherInterface` renamed to `DispatcherInterface`.
