### PR TITLE
JS capturer controller class renamed

### DIFF
--- a/sapi.routing.yml
+++ b/sapi.routing.yml
@@ -1,7 +1,7 @@
 sapi.sapi_js_capture:
   path: 'sapi/js/capture'
   defaults:
-    _controller: '\Drupal\sapi\Controller\SapiJsCaptureController::capture'
+    _controller: '\Drupal\sapi\Controller\JsActionCaptureController::capture'
     _title: 'JS action capture controller'
   requirements:
     _permission: 'sapi capture js actions'

--- a/src/Controller/JsActionCaptureController.php
+++ b/src/Controller/JsActionCaptureController.php
@@ -13,11 +13,11 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
- * Class SapiJsCaptureController.
+ * Class JsActionCaptureController.
  *
  * @package Drupal\sapi
  */
-class SapiJsCaptureController extends ControllerBase implements ContainerInjectionInterface {
+class JsActionCaptureController extends ControllerBase implements ContainerInjectionInterface {
 
   /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
   protected $requestStack;
@@ -25,7 +25,7 @@ class SapiJsCaptureController extends ControllerBase implements ContainerInjecti
   protected $sapiDispatcher;
 
   /**
-   * SapiJsCaptureController constructor.
+   * JsActionCaptureController constructor.
    *
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    * @param \Drupal\sapi\SapiDispatcherInterface $sapiDispatcher


### PR DESCRIPTION
To remove the usage of `Sapi` prefix everywhere, `SapiJsCaptureController` class renamed to `JsActionCaptureController`.
