### PR TITLE
Module package name change to first letter uppercase

### DIFF
--- a/sapi.info.yml
+++ b/sapi.info.yml
@@ -2,4 +2,4 @@ name: Statistics API (version 2)
 type: module
 description: Statistics API module which provides a base for statistics harvesting through plugins.
 core: 8.x
-package: statistics
+package: Statistics


### PR DESCRIPTION
`Statistics` and `statistics` make it two separate module groups. This PR streamlines that to a single module group - `Statistics`.
