### PR TITLE
dispatcher cleanup & formatting and docs

### DIFF
--- a/sapi.services.yml
+++ b/sapi.services.yml
@@ -1,7 +1,7 @@
 services:
   sapi.dispatcher:
     class: Drupal\sapi\Dispatcher
-    arguments: [ "@plugin.manager.sapi_action_handler" ]
+    arguments: ["@plugin.manager.sapi_action_handler"]
 
   plugin.manager.sapi_action_type:
     class: Drupal\sapi\ActionTypeManager

--- a/sapi.services.yml
+++ b/sapi.services.yml
@@ -1,7 +1,7 @@
 services:
   sapi.dispatcher:
     class: Drupal\sapi\Dispatcher
-    arguments: ["@config.manager", "@current_user", "@current_route_match", "@plugin.manager.sapi_action_handler", "@service_container"]
+    arguments: [ "@plugin.manager.sapi_action_handler" ]
 
   plugin.manager.sapi_action_type:
     class: Drupal\sapi\ActionTypeManager

--- a/src/Annotation/ActionHandler.php
+++ b/src/Annotation/ActionHandler.php
@@ -7,7 +7,7 @@ use Drupal\Component\Annotation\Plugin;
 /**
  * Defines a Statistics action handler item annotation object.
  *
- * @see \Drupal\sapi\Plugin\ActionHandlerManager
+ * @see \Drupal\sapi\ActionHandlerManager
  * @see plugin_api
  *
  * @Annotation

--- a/src/Annotation/ActionType.php
+++ b/src/Annotation/ActionType.php
@@ -7,7 +7,7 @@ use Drupal\Component\Annotation\Plugin;
 /**
  * Defines a Statistics action type item annotation object.
  *
- * @see \Drupal\sapi\Plugin\ActionTypeManager
+ * @see \Drupal\sapi\ActionTypeManager
  * @see plugin_api
  *
  * @Annotation

--- a/src/Controller/JsActionCaptureController.php
+++ b/src/Controller/JsActionCaptureController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\sapi\Controller;
 
+use Drupal\Component\Plugin\PluginManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\sapi\DispatcherInterface;
@@ -11,7 +12,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Drupal\Component\Plugin\PluginManagerInterface;
 
 /**
  * Class JsActionCaptureController.
@@ -51,7 +51,8 @@ class JsActionCaptureController extends ControllerBase implements ContainerInjec
    *
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    * @param \Drupal\sapi\DispatcherInterface $sapiDispatcher
-   * @param ContainerInterface $container
+   * @param \Drupal\Component\Plugin\PluginManagerInterface $sapi_action_type_manager
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
    */
   public function __construct(RequestStack $requestStack, DispatcherInterface $sapiDispatcher, PluginManagerInterface $sapi_action_type_manager, ContainerInterface $container) {
     $this->requestStack = $requestStack;

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\sapi;
 
-use Drupal\Core\Config\ConfigManager;
-use Drupal\Core\Session\AccountProxy;
-use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Component\Plugin\PluginManagerInterface;
 
 /**
@@ -13,27 +10,6 @@ use Drupal\Component\Plugin\PluginManagerInterface;
  * @package Drupal\sapi
  */
 class Dispatcher implements DispatcherInterface {
-
-  /**
-   * Drupal\Core\Config\ConfigManager definition.
-   *
-   * @var \Drupal\Core\Config\ConfigManager
-   */
-  protected $configManager;
-
-  /**
-   * Drupal\Core\Session\AccountProxy definition.
-   *
-   * @var \Drupal\Core\Session\AccountProxy
-   */
-  protected $currentUser;
-
-  /**
-   * Drupal\Core\Routing\CurrentRouteMatch definition.
-   *
-   * @var \Drupal\Core\Routing\CurrentRouteMatch
-   */
-  protected $currentRouteMatch;
 
   /**
    * Drupal\Component\Plugin\PluginManagerInterface definition.
@@ -45,15 +21,9 @@ class Dispatcher implements DispatcherInterface {
   /**
    * Dispatcher constructor.
    *
-   * @param \Drupal\Core\Config\ConfigManager $configManager
-   * @param \Drupal\Core\Session\AccountProxy $currentUser
-   * @param \Drupal\Core\Routing\CurrentRouteMatch $currentRouteMatch
    * @param \Drupal\Component\Plugin\PluginManagerInterface $SAPIActionHandlerPluginManager
    */
-  public function __construct(ConfigManager $configManager, AccountProxy $currentUser, CurrentRouteMatch $currentRouteMatch, PluginManagerInterface $SAPIActionHandlerPluginManager) {
-    $this->configManager = $configManager;
-    $this->currentUser = $currentUser;
-    $this->currentRouteMatch = $currentRouteMatch;
+  public function __construct(PluginManagerInterface $SAPIActionHandlerPluginManager) {
     $this->SAPIActionHandlerPluginManager = $SAPIActionHandlerPluginManager;
   }
 

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -17,7 +17,6 @@ interface DispatcherInterface {
    *
    * @return void
    *
-   * @todo should we pass anything into the handler plugin constructor?
    */
   public function dispatch(ActionTypeInterface $action);
 

--- a/src/Form/StatisticsPluginListForm.php
+++ b/src/Form/StatisticsPluginListForm.php
@@ -76,19 +76,6 @@ class StatisticsPluginListForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
-    $form['entity_events'] = [
-      '#type' => 'fieldset',
-      '#title' => $this->t('Configure entity events') ,
-      '#description' => $this->t('Configure the settings for the event tracker.')
-    ];
-    $form['entity_events']['event_route_subscriber'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Enable the entity events subscriber'),
-      '#description' => $this->t('Check this to enable the event subscriber which will listen for entity routes, and trigger actions based on them.'),
-      '#default value' => $this->config('sapi.entity_events')->get('event_route_subscriber')
-    ];
-    
-    
     $form['plugins'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Statistics plugins'),
@@ -146,10 +133,6 @@ class StatisticsPluginListForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     parent::submitForm($form, $form_state);
-
-    $this->config('sapi.entity_events')
-      ->set('event_route_subscriber', array_filter($form_state->getValue('event_route_subscriber')))
-      ->save();
 
     $this->config('sapi.action_types')
       ->set('enabled', array_filter($form_state->getValue('action_types')))

--- a/src/Plugin/Statistics/ActionHandler/ActionLogger.php
+++ b/src/Plugin/Statistics/ActionHandler/ActionLogger.php
@@ -2,30 +2,46 @@
 
 namespace Drupal\sapi\Plugin\Statistics\ActionHandler;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\sapi\ActionHandlerBase;
 use Drupal\sapi\ActionHandlerInterface;
 use Drupal\sapi\ActionTypeInterface;
-use Drupal\Core\Logger\LoggerChannelFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @ActionHandler (
  *  id = "action_logger",
  *  label = "Log any received actions"
  * )
+ *
+ * Testing action handler, which only logs the ->describe() string of every
+ * received plugin, so that you can check the Drupal logs to see if actions
+ * are being sent properly.
+ *
  */
 class ActionLogger extends ActionHandlerBase implements ActionHandlerInterface, ContainerFactoryPluginInterface {
 
-  /** @var \Drupal\Core\Logger\LoggerChannelInterface $logger    */
+  /**
+   * Logger used to track handling
+   *
+   * @protected \Drupal\Core\Logger\LoggerChannelInterface $logger
+   */
   protected $logger;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelFactory $loggerFactory) {
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   a logger factory, which will be used to generate the logger
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelFactoryInterface $loggerFactory) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     // don't keep the whole factory, just the one logger
     $this->logger = $loggerFactory->get('sapi');
   }
+
   /**
    * {@inheritdoc}
    */

--- a/src/Plugin/Statistics/ActionType/Dummy.php
+++ b/src/Plugin/Statistics/ActionType/Dummy.php
@@ -10,6 +10,11 @@ use Drupal\sapi\ActionTypeInterface;
  *   id = "dummy",
  *   label = "Dummy action item"
  * )
+ *
+ * A zero-requirements action plugin that can be used to test if actions are
+ * being sent properly to handlers.  You could use this for generic action
+ * triggers, but really actions should be more conservative.
+ *
  */
 class Dummy extends ActionTypeBase implements ActionTypeInterface {
 

--- a/src/Plugin/Statistics/ActionType/Tagged.php
+++ b/src/Plugin/Statistics/ActionType/Tagged.php
@@ -10,6 +10,14 @@ use Drupal\sapi\ActionTypeInterface;
  *   id = "tagged",
  *   label = "Tagged action item"
  * )
+ *
+ * A taggeable action type, where a handler can compare tags to determine if
+ * it should process.  This action type holds no data other than the tag.
+ *
+ * To use this, pass in a tag when using the manager to create an instance,
+ * and then in your handler code, confirm that the plugin has the required
+ * tag.
+ *
  */
 class Tagged extends ActionTypeBase implements ActionTypeInterface {
 


### PR DESCRIPTION
After comments added to recent PR, this PR should clean things up a bit

This patch cleans up the sapi codebase:
- lots of documentation additions
- proper ordering of use statements
- fixed a few missing and incorrect @var/@param/@protected declarations
- removed some unused form controls
- removed unused Dispatcher dependencies from injection
