### PR TITLE
Dispatcher uses only enabled Handler plugins

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -34,10 +34,12 @@ class Dispatcher implements DispatcherInterface {
     /** @var \Drupal\sapi\ActionHandlerInterface $instance */
     foreach ($this->SAPIActionHandlerPluginManager->getDefinitions() as $pluginDefinition) {
       try {
-        /** @var \Drupal\sapi\ActionHandlerInterface $instance */
-        $instance = $this->SAPIActionHandlerPluginManager->createInstance($pluginDefinition['id']);
-
-        $instance->process($action);
+        $enabled = \Drupal::config('sapi.action_handlers')->get('enabled');
+        if (in_array($pluginDefinition['id'], $enabled)){
+          /** @var \Drupal\sapi\ActionHandlerInterface $instance */
+          $instance = $this->SAPIActionHandlerPluginManager->createInstance($pluginDefinition['id']);
+          $instance->process($action);
+        }
       } catch (\Exception $e) {
         \Drupal::logger('default')->error("Error during SAPI dispatch : ".$e->getMessage());
       }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -31,10 +31,10 @@ class Dispatcher implements DispatcherInterface {
    * {@inheritdoc}
    */
   public function dispatch(ActionTypeInterface $action) {
+    $enabled = \Drupal::config('sapi.action_handlers')->get('enabled');
     /** @var \Drupal\sapi\ActionHandlerInterface $instance */
     foreach ($this->SAPIActionHandlerPluginManager->getDefinitions() as $pluginDefinition) {
       try {
-        $enabled = \Drupal::config('sapi.action_handlers')->get('enabled');
         if (in_array($pluginDefinition['id'], $enabled)){
           /** @var \Drupal\sapi\ActionHandlerInterface $instance */
           $instance = $this->SAPIActionHandlerPluginManager->createInstance($pluginDefinition['id']);

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -31,17 +31,16 @@ class Dispatcher implements DispatcherInterface {
    * {@inheritdoc}
    */
   public function dispatch(ActionTypeInterface $action) {
+    /** @var []string $enabled */
     $enabled = \Drupal::config('sapi.action_handlers')->get('enabled');
-    /** @var \Drupal\sapi\ActionHandlerInterface $instance */
-    foreach ($this->SAPIActionHandlerPluginManager->getDefinitions() as $pluginDefinition) {
+    foreach ($enabled as $id) {
       try {
-        if (in_array($pluginDefinition['id'], $enabled)){
-          /** @var \Drupal\sapi\ActionHandlerInterface $instance */
-          $instance = $this->SAPIActionHandlerPluginManager->createInstance($pluginDefinition['id']);
-          $instance->process($action);
-        }
+        /** @var \Drupal\sapi\ActionHandlerInterface $instance */
+        $instance = $this->SAPIActionHandlerPluginManager->createInstance($id);
+        $instance->process($action);
       } catch (\Exception $e) {
-        \Drupal::logger('default')->error("Error during SAPI dispatch : ".$e->getMessage());
+        \Drupal::logger('default')
+          ->error("Error during SAPI dispatch : " . $e->getMessage());
       }
     }
   }


### PR DESCRIPTION
**Dispatcher->dispatch() gets enabled action_handlers ID's and creates Instances to pass action to.**

Method dispatch uses _sapi.action_handlers_ configuration to retrieve enabled plugins. 
Plugins gets enabled in admin settings form "admin/config/sapi/statistics-plugins".
- [Issue #27](https://github.com/james-nesbitt/drupal-sapi2-prototype/issues/27)
-  [Trello card](https://trello.com/c/UQ5V0bzI/39-sapi-dispatcher-should-only-use-handler-plugins-that-have-been-enabled-in-the-admin-settings-form)
