### PR TITLE
Adds manage tabs when editing a SAPI data Type

### DIFF
--- a/modules/sapi_data/sapi_data.links.task.yml
+++ b/modules/sapi_data/sapi_data.links.task.yml
@@ -12,6 +12,13 @@ sapi_data.sapi_data_settings_form:
   base_route: entity.sapi_data_type.collection
   title: 'Settings'
 
+# Statistics API Data entity managing
+entity.sapi_data_type.edit_form:
+  route_name: entity.sapi_data_type.edit_form
+  base_route: entity.sapi_data_type.edit_form
+  title: 'Edit'
+
+
 # Statistics API Data entry routing definition
 entity.sapi_data.canonical:
   route_name: entity.sapi_data.canonical


### PR DESCRIPTION
**Fixes bub #23 - No manage tabs when editing a SAPI data Type.**
Adds:
- Manage fields
- Manage form display
- Manage display

[Issue: #23 ](When editing a SAPI data Type %28config entity%29 there should be tabs to switched to editing fields #23)

[Trello card](https://trello.com/c/6VBvJvhr/40-bug-as-an-administrator-i-would-like-to-see-consistent-tabs-when-navigating-the-sapi-data-content-item-so-that-the-experience-fe)
