### PR TITLE
Added sapi_entity_interaction module

### DIFF
--- a/modules/sapi_entity_interaction/composer.json
+++ b/modules/sapi_entity_interaction/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "drupal/sapi_entity_interaction",
+  "type": "drupal-module",
+  "description": "This module tracks user interactions(View, Create, Update) to any entity. This module also requires other contrib modules.",
+  "license": "GPL-2.0+",
+  "minimum-stability": "dev",
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packagist.drupal-composer.org"
+    }
+  ],
+  "require": {
+    "drupal/dynamic_entity_reference": "8.1.0-rc4"
+  }
+}

--- a/modules/sapi_entity_interaction/config/install/block.block.views_block__hottest_users_biggest_contrib_users_block.yml
+++ b/modules/sapi_entity_interaction/config/install/block.block.views_block__hottest_users_biggest_contrib_users_block.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.hottest_users
+  module:
+    - views
+  theme:
+    - bartik
+id: views_block__hottest_users_biggest_contrib_users_block
+theme: bartik
+region: sidebar_second
+weight: -8
+provider: null
+plugin: 'views_block:hottest_users-biggest_contrib_users_block'
+settings:
+  id: 'views_block:hottest_users-biggest_contrib_users_block'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility: {  }

--- a/modules/sapi_entity_interaction/config/install/block.block.views_block__most_viewed_articles_most_viewed_articles_block.yml
+++ b/modules/sapi_entity_interaction/config/install/block.block.views_block__most_viewed_articles_most_viewed_articles_block.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.most_viewed_articles
+  module:
+    - views
+  theme:
+    - bartik
+id: views_block__most_viewed_articles_most_viewed_articles_block
+theme: bartik
+region: sidebar_second
+weight: -8
+provider: null
+plugin: 'views_block:most_viewed_articles-most_viewed_articles_block'
+settings:
+  id: 'views_block:most_viewed_articles-most_viewed_articles_block'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility: {  }

--- a/modules/sapi_entity_interaction/config/install/core.entity_form_display.sapi_data.entity_interactions.default.yml
+++ b/modules/sapi_entity_interaction/config/install/core.entity_form_display.sapi_data.entity_interactions.default.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.sapi_data.entity_interactions.field_entity_reference
+    - field.field.sapi_data.entity_interactions.field_interaction_type
+    - field.field.sapi_data.entity_interactions.field_user
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - dynamic_entity_reference
+    - sapi_entity_interaction
+id: sapi_data.entity_interactions.default
+targetEntityType: sapi_data
+bundle: entity_interactions
+mode: default
+content:
+  field_entity_reference:
+    weight: 15
+    settings:
+      match_operator: CONTAINS
+      size: 40
+      placeholder: ''
+    third_party_settings: {  }
+    type: dynamic_entity_reference_default
+  field_interaction_type:
+    weight: 14
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+  field_user:
+    weight: 12
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+  langcode:
+    type: language_select
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  user_id:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/sapi_entity_interaction/config/install/core.entity_view_display.sapi_data.entity_interactions.default.yml
+++ b/modules/sapi_entity_interaction/config/install/core.entity_view_display.sapi_data.entity_interactions.default.yml
@@ -1,0 +1,52 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.sapi_data.entity_interactions.field_entity_reference
+    - field.field.sapi_data.entity_interactions.field_interaction_type
+    - field.field.sapi_data.entity_interactions.field_user
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - dynamic_entity_reference
+    - user
+    - sapi_entity_interaction
+id: sapi_data.entity_interactions.default
+targetEntityType: sapi_data
+bundle: entity_interactions
+mode: default
+content:
+  field_entity_reference:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: dynamic_entity_reference_label
+  field_interaction_type:
+    weight: 4
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+  field_user:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  name:
+    label: above
+    type: string
+    weight: -4
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  user_id:
+    label: hidden
+    type: author
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/sapi_entity_interaction/config/install/field.field.sapi_data.entity_interactions.field_entity_reference.yml
+++ b/modules/sapi_entity_interaction/config/install/field.field.sapi_data.entity_interactions.field_entity_reference.yml
@@ -1,0 +1,111 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_entity_reference
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - dynamic_entity_reference
+    - sapi_entity_interaction
+id: sapi_data.entity_interactions.field_entity_reference
+field_name: field_entity_reference
+entity_type: sapi_data
+bundle: entity_interactions
+label: 'Entity Reference'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  comment:
+    handler: 'default:comment'
+    handler_settings:
+      target_bundles:
+        comment: comment
+      sort:
+        field: _none
+      auto_create: false
+      auto_create_bundle: ''
+  contact_message:
+    handler: 'default:contact_message'
+    handler_settings:
+      target_bundles:
+        personal: personal
+        feedback: feedback
+      sort:
+        field: _none
+      auto_create: false
+      auto_create_bundle: personal
+  node:
+    handler: 'default:node'
+    handler_settings:
+      target_bundles:
+        article: article
+        page: page
+      sort:
+        field: _none
+      auto_create: false
+  block_content:
+    handler: 'default:block_content'
+    handler_settings:
+      target_bundles:
+        basic: basic
+      sort:
+        field: _none
+      auto_create: false
+      auto_create_bundle: ''
+  menu_link_content:
+    handler: 'default:menu_link_content'
+    handler_settings:
+      target_bundles:
+        menu_link_content: menu_link_content
+      sort:
+        field: _none
+      auto_create: false
+      auto_create_bundle: ''
+  file:
+    handler: 'default:file'
+    handler_settings:
+      target_bundles: null
+      sort:
+        field: _none
+      auto_create: false
+  shortcut:
+    handler: 'default:shortcut'
+    handler_settings:
+      target_bundles:
+        default: default
+      sort:
+        field: _none
+      auto_create: false
+      auto_create_bundle: ''
+  sapi_data:
+    handler: 'default:sapi_data'
+    handler_settings:
+      target_bundles:
+        color_frequency: color_frequency
+        entity_interactions: entity_interactions
+      sort:
+        field: _none
+      auto_create: false
+      auto_create_bundle: color_frequency
+  taxonomy_term:
+    handler: 'default:taxonomy_term'
+    handler_settings:
+      target_bundles:
+        tags: tags
+      sort:
+        field: _none
+      auto_create: false
+  user:
+    handler: 'default:user'
+    handler_settings:
+      include_anonymous: true
+      filter:
+        type: _none
+      target_bundles: null
+      sort:
+        field: _none
+      auto_create: false
+field_type: dynamic_entity_reference

--- a/modules/sapi_entity_interaction/config/install/field.field.sapi_data.entity_interactions.field_interaction_type.yml
+++ b/modules/sapi_entity_interaction/config/install/field.field.sapi_data.entity_interactions.field_interaction_type.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_interaction_type
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - sapi_entity_interaction
+id: sapi_data.entity_interactions.field_interaction_type
+field_name: field_interaction_type
+entity_type: sapi_data
+bundle: entity_interactions
+label: 'Interaction type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/sapi_entity_interaction/config/install/field.field.sapi_data.entity_interactions.field_user.yml
+++ b/modules/sapi_entity_interaction/config/install/field.field.sapi_data.entity_interactions.field_user.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_user
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - sapi_entity_interaction
+id: sapi_data.entity_interactions.field_user
+field_name: field_user
+entity_type: sapi_data
+bundle: entity_interactions
+label: User
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    include_anonymous: true
+    filter:
+      type: _none
+    target_bundles: null
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/modules/sapi_entity_interaction/config/install/field.storage.sapi_data.field_entity_reference.yml
+++ b/modules/sapi_entity_interaction/config/install/field.storage.sapi_data.field_entity_reference.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - comment
+    - contact
+    - dynamic_entity_reference
+    - file
+    - menu_link_content
+    - node
+    - sapi_data
+    - shortcut
+    - taxonomy
+    - user
+    - sapi_entity_interaction
+id: sapi_data.field_entity_reference
+field_name: field_entity_reference
+entity_type: sapi_data
+type: dynamic_entity_reference
+settings:
+  exclude_entity_types: true
+  entity_type_ids: {  }
+module: dynamic_entity_reference
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/sapi_entity_interaction/config/install/field.storage.sapi_data.field_interaction_type.yml
+++ b/modules/sapi_entity_interaction/config/install/field.storage.sapi_data.field_interaction_type.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_data
+    - sapi_entity_interaction
+id: sapi_data.field_interaction_type
+field_name: field_interaction_type
+entity_type: sapi_data
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/sapi_entity_interaction/config/install/field.storage.sapi_data.field_user.yml
+++ b/modules/sapi_entity_interaction/config/install/field.storage.sapi_data.field_user.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_data
+    - user
+    - sapi_entity_interaction
+id: sapi_data.field_user
+field_name: field_user
+entity_type: sapi_data
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/sapi_entity_interaction/config/install/sapi_data.sapi_data_type.entity_interactions.yml
+++ b/modules/sapi_entity_interaction/config/install/sapi_data.sapi_data_type.entity_interactions.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_entity_interaction
+id: entity_interactions
+label: 'Entity interactions'

--- a/modules/sapi_entity_interaction/config/install/views.view.entity_view_count_list.yml
+++ b/modules/sapi_entity_interaction/config/install/views.view.entity_view_count_list.yml
@@ -1,0 +1,428 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_entity_reference
+    - sapi_data.sapi_data_type.entity_interactions
+    - system.menu.admin
+    - user.role.administrator
+  module:
+    - dynamic_entity_reference
+    - sapi_data
+    - user
+    - sapi_entity_interaction
+id: entity_view_count_list
+label: 'Entity view count list'
+module: views
+description: ''
+tag: ''
+base_table: sapi_data
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            field_entity_reference: field_entity_reference
+            field_entity_reference_2: field_entity_reference_2
+            field_entity_reference_1: field_entity_reference_1
+          info:
+            field_entity_reference:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_entity_reference_2:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_entity_reference_1:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: field_entity_reference_1
+          empty_table: true
+      row:
+        type: fields
+      fields:
+        field_entity_reference:
+          id: field_entity_reference
+          table: sapi_data__field_entity_reference
+          field: field_entity_reference
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Entity
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: dynamic_entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns:
+            target_type: target_type
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_entity_reference_2:
+          id: field_entity_reference_2
+          table: sapi_data__field_entity_reference
+          field: field_entity_reference
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Entity Type'
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{field_entity_reference_2__target_type}}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_type
+          type: dynamic_entity_reference_label
+          settings:
+            link: true
+          group_column: target_type
+          group_columns:
+            target_id: target_id
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_entity_reference_1:
+          id: field_entity_reference_1
+          table: sapi_data__field_entity_reference
+          field: field_entity_reference
+          relationship: none
+          group_type: count
+          admin_label: ''
+          label: 'View Count'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ', '
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          click_sort_column: target_id
+          type: dynamic_entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        type:
+          id: type
+          table: sapi_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            min: ''
+            max: ''
+            value: ''
+            entity_interactions: entity_interactions
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: sapi_data
+          entity_field: type
+          plugin_id: bundle
+        field_interaction_type_value:
+          id: field_interaction_type_value
+          table: sapi_data__field_interaction_type
+          field: field_interaction_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: View
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+      sorts: {  }
+      title: 'Entity view count list'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      group_by: true
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.roles
+      tags:
+        - 'config:field.storage.sapi_data.field_entity_reference'
+  entity_view_count_list:
+    display_plugin: page
+    id: entity_view_count_list
+    display_title: 'Entity view count list'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/structure/sapi/entity-view-count-list
+      menu:
+        type: normal
+        title: 'Entity view count list'
+        description: ''
+        expanded: false
+        parent: sapi_data.sapi_data_structure
+        weight: 0
+        context: '0'
+        menu_name: admin
+      tab_options:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+      display_description: ''
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.roles
+      tags:
+        - 'config:field.storage.sapi_data.field_entity_reference'

--- a/modules/sapi_entity_interaction/config/install/views.view.hottest_users.yml
+++ b/modules/sapi_entity_interaction/config/install/views.view.hottest_users.yml
@@ -1,0 +1,1020 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.admin
+    - user.role.administrator
+  module:
+    - node
+    - sapi_data
+    - user
+    - sapi_entity_interaction
+id: hottest_users
+label: 'Hottest users'
+module: views
+description: 'Users who have contributed the most'
+tag: ''
+base_table: users_field_data
+base_field: uid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 5
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: 'user/{{ name }}/contributions'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns:
+            value: value
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          set_precision: false
+          precision: 0
+          decimal: .
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: none
+          group_type: count
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'Created and/or updated {{ uid }} posts.'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ', '
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: null
+          group_columns: null
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
+      filters:
+        field_interaction_type_value:
+          id: field_interaction_type_value
+          table: sapi_data__field_interaction_type
+          field: field_interaction_type_value
+          relationship: reverse__sapi_data__field_user
+          group_type: group
+          admin_label: ''
+          operator: '!='
+          value: View
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+      sorts:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: none
+          group_type: count
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: user
+          entity_field: uid
+          plugin_id: standard
+      title: 'Entity user view count list page'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        reverse__sapi_data__field_user:
+          id: reverse__sapi_data__field_user
+          table: users_field_data
+          field: reverse__sapi_data__field_user
+          relationship: none
+          group_type: group
+          admin_label: field_user
+          required: true
+          entity_type: user
+          plugin_id: entity_reverse
+        node__field_entity_reference:
+          id: node__field_entity_reference
+          table: sapi_data__field_entity_reference
+          field: node__field_entity_reference
+          relationship: reverse__sapi_data__field_user
+          group_type: group
+          admin_label: 'field_entity_reference: Content'
+          required: true
+          plugin_id: standard
+      arguments:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: user_uid
+      display_extenders: {  }
+      group_by: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+      tags: {  }
+  biggest_contrib_users_block:
+    display_plugin: block
+    id: biggest_contrib_users_block
+    display_title: 'Hottest users'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Biggest contributors'
+      display_description: 'Users who have contributed the most.'
+      arguments: {  }
+      defaults:
+        arguments: false
+        title: false
+      block_hide_empty: true
+      title: 'Top 5 contributers'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags: {  }
+  entity_user_view_count_list_page:
+    display_plugin: page
+    id: entity_user_view_count_list_page
+    display_title: 'Entity user view count list page'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      menu:
+        type: normal
+        title: 'Entity user view count list'
+        description: ''
+        expanded: false
+        parent: sapi_data.sapi_data_structure
+        weight: 2
+        context: '0'
+        menu_name: admin
+      path: admin/structure/sapi/entity_user_view_count_list
+      filters:
+        field_interaction_type_value:
+          id: field_interaction_type_value
+          table: sapi_data__field_interaction_type
+          field: field_interaction_type_value
+          relationship: reverse__sapi_data__field_user
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: View
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+      defaults:
+        filters: false
+        filter_groups: false
+        fields: false
+        style: false
+        row: false
+        relationships: false
+        access: false
+        empty: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Username
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: 'user/{{ name }}/contributions'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns:
+            value: value
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          set_precision: false
+          precision: 0
+          decimal: .
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        mail:
+          id: mail
+          table: users_field_data
+          field: mail
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Email
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: entity_id
+          group_columns:
+            value: value
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: none
+          group_type: count
+          admin_label: ''
+          label: 'View count'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ' {{ uid }} posts.'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ', '
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: null
+          group_columns: null
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            name: name
+            mail: mail
+            uid: uid
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            mail:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: fields
+        options: {  }
+      relationships:
+        reverse__sapi_data__field_user:
+          id: reverse__sapi_data__field_user
+          table: users_field_data
+          field: reverse__sapi_data__field_user
+          relationship: none
+          group_type: group
+          admin_label: field_user
+          required: true
+          entity_type: user
+          plugin_id: entity_reverse
+      display_description: ''
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No content view yet. '
+            format: basic_html
+          plugin_id: text
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.roles
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: 'Admins content providers page'
+    position: 3
+    display_options:
+      display_extenders: {  }
+      arguments: {  }
+      defaults:
+        arguments: false
+        style: false
+        row: false
+        fields: false
+        title: false
+        access: false
+        empty: false
+      path: admin/structure/sapi/entity_user_content_providers
+      menu:
+        type: normal
+        title: 'Content providers'
+        description: ''
+        expanded: false
+        parent: sapi_data.sapi_data_structure
+        weight: 5
+        context: '0'
+        menu_name: admin
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            name: name
+            mail: mail
+            uid: uid
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            mail:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: fields
+        options: {  }
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Username
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: 'user/{{ name }}/contributions'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns:
+            value: value
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          set_precision: false
+          precision: 0
+          decimal: .
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        mail:
+          id: mail
+          table: users_field_data
+          field: mail
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Email
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: entity_id
+          group_columns:
+            value: value
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: none
+          group_type: count
+          admin_label: ''
+          label: 'Content edited'
+          exclude: false
+          alter:
+            alter_text: false
+            text: 'Created and/or updated {{ uid }} posts.'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ', '
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: null
+          group_columns: null
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
+      title: 'Content providers'
+      display_description: ''
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No content provided yet. '
+            format: basic_html
+          plugin_id: text
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.roles
+      tags: {  }

--- a/modules/sapi_entity_interaction/config/install/views.view.most_viewed_articles.yml
+++ b/modules/sapi_entity_interaction/config/install/views.view.most_viewed_articles.yml
@@ -245,6 +245,42 @@ display:
           entity_type: sapi_data
           entity_field: created
           plugin_id: date
+        field_interaction_type_value:
+          id: field_interaction_type_value
+          table: sapi_data__field_interaction_type
+          field: field_interaction_type_value
+          relationship: reverse__sapi_data__field_entity_reference
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: View
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
       sorts:
         nid:
           id: nid

--- a/modules/sapi_entity_interaction/config/install/views.view.most_viewed_articles.yml
+++ b/modules/sapi_entity_interaction/config/install/views.view.most_viewed_articles.yml
@@ -1,0 +1,306 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - sapi_data
+    - user
+    - sapi_entity_interaction
+id: most_viewed_articles
+label: 'Most viewed articles'
+module: views
+description: 'List of the most viewed node-articles for last week (the last seven days)'
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 5
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: count
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'Viewed: {{ nid }} times in last 7 days.'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ', '
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          click_sort_column: value
+          type: number_integer
+          settings: {  }
+          group_column: entity_id
+          group_columns:
+            entity_id: entity_id
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          field_api_classes: false
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+      filters:
+        status:
+          value: true
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        created:
+          id: created
+          table: sapi_data
+          field: created
+          relationship: reverse__sapi_data__field_entity_reference
+          group_type: group
+          admin_label: ''
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: '-7 days'
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: sapi_data
+          entity_field: created
+          plugin_id: date
+      sorts:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: count
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+      title: 'Most viewed article'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        reverse__sapi_data__field_entity_reference:
+          id: reverse__sapi_data__field_entity_reference
+          table: node_field_data
+          field: reverse__sapi_data__field_entity_reference
+          relationship: none
+          group_type: group
+          admin_label: field_entity_reference
+          required: false
+          entity_type: node
+          plugin_id: entity_reverse
+      arguments: {  }
+      display_extenders: {  }
+      group_by: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  most_viewed_articles_block:
+    display_plugin: block
+    id: most_viewed_articles_block
+    display_title: 'Most viewed articles block'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Most viewed articles (last week)'
+      display_description: 'Most viewed articles for last 7 days.'
+      block_hide_empty: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/modules/sapi_entity_interaction/config/install/views.view.user_contributions.yml
+++ b/modules/sapi_entity_interaction/config/install/views.view.user_contributions.yml
@@ -1,0 +1,630 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_interaction_type
+    - field.storage.sapi_data.field_user
+    - system.menu.account
+    - user.role.administrator
+    - user.role.authenticated
+  module:
+    - node
+    - sapi_data
+    - user
+    - sapi_entity_interaction
+id: user_contributions
+label: 'User contributions'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: role
+        options:
+          role:
+            authenticated: authenticated
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 0
+          offset: 0
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            field_user: field_user
+            created: created
+            field_interaction_type: field_interaction_type
+            title: title
+          info:
+            field_user:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_interaction_type:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: fields
+      fields:
+        field_user:
+          id: field_user
+          table: sapi_data__field_user
+          field: field_user
+          relationship: reverse__sapi_data__field_entity_reference
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        created:
+          id: created
+          table: sapi_data
+          field: created
+          relationship: reverse__sapi_data__field_entity_reference
+          group_type: group
+          admin_label: ''
+          label: Date
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: sapi_data
+          entity_field: created
+          plugin_id: field
+        field_interaction_type:
+          id: field_interaction_type
+          table: sapi_data__field_interaction_type
+          field: field_interaction_type
+          relationship: reverse__sapi_data__field_entity_reference
+          group_type: group
+          admin_label: ''
+          label: Action
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Post
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+      filters:
+        status:
+          value: true
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_interaction_type_value:
+          id: field_interaction_type_value
+          table: sapi_data__field_interaction_type
+          field: field_interaction_type_value
+          relationship: reverse__sapi_data__field_entity_reference
+          group_type: group
+          admin_label: ''
+          operator: '!='
+          value: View
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+      sorts:
+        created:
+          id: created
+          table: sapi_data
+          field: created
+          relationship: reverse__sapi_data__field_entity_reference
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: sapi_data
+          entity_field: created
+          plugin_id: date
+      title: 'User contributions'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        reverse__sapi_data__field_entity_reference:
+          id: reverse__sapi_data__field_entity_reference
+          table: node_field_data
+          field: reverse__sapi_data__field_entity_reference
+          relationship: none
+          group_type: group
+          admin_label: field_entity_reference
+          required: true
+          entity_type: node
+          plugin_id: entity_reverse
+        field_user:
+          id: field_user
+          table: sapi_data__field_user
+          field: field_user
+          relationship: reverse__sapi_data__field_entity_reference
+          group_type: group
+          admin_label: 'field_user: User'
+          required: true
+          plugin_id: standard
+      arguments:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: field_user
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: user
+          entity_field: name
+          plugin_id: string
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.sapi_data.field_interaction_type'
+        - 'config:field.storage.sapi_data.field_user'
+  my_contributions_page:
+    display_plugin: page
+    id: my_contributions_page
+    display_title: 'My contributions page'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      title: 'My contributions'
+      defaults:
+        title: false
+        arguments: false
+        empty: false
+      display_description: ''
+      arguments:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: field_user
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: current_user
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: user_uid
+      path: my_contributions
+      menu:
+        type: normal
+        title: 'My contributions'
+        description: ''
+        expanded: true
+        parent: ''
+        weight: 2
+        context: '0'
+        menu_name: account
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'You have not created or edited any post.'
+            format: basic_html
+          plugin_id: text
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - user
+        - 'user.node_grants:view'
+        - user.roles
+      tags:
+        - 'config:field.storage.sapi_data.field_interaction_type'
+        - 'config:field.storage.sapi_data.field_user'
+  user_contributions_page:
+    display_plugin: page
+    id: user_contributions_page
+    display_title: 'User contributions page'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: user/%user/contributions
+      display_description: ''
+      menu:
+        type: none
+        title: 'My hystory'
+        description: ''
+        expanded: false
+        parent: ''
+        weight: 3
+        context: '0'
+        menu_name: account
+      access:
+        type: none
+        options: {  }
+      defaults:
+        access: false
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.sapi_data.field_interaction_type'
+        - 'config:field.storage.sapi_data.field_user'

--- a/modules/sapi_entity_interaction/sapi_entity_interaction.info.yml
+++ b/modules/sapi_entity_interaction/sapi_entity_interaction.info.yml
@@ -1,0 +1,13 @@
+name: Statistics API Entity Interaction
+type: module
+description: This module tracks user interactions(View, Create, Update) to any entity.
+core: 8.x
+package: Statistics
+dependencies:
+  - sapi
+  - sapi_data
+  - node
+  - taxonomy
+  - field
+  - datetime
+  - dynamic_entity_reference

--- a/modules/sapi_entity_interaction/sapi_entity_interaction.install
+++ b/modules/sapi_entity_interaction/sapi_entity_interaction.install
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Implements hook_uninstall().
+ */
+function sapi_entity_interaction_uninstall() {
+  // Remove field_colors field on uninstall.
+  Drupal::configFactory()->getEditable('field.storage.node.field_colors')->delete();
+}

--- a/modules/sapi_entity_interaction/sapi_entity_interaction.install
+++ b/modules/sapi_entity_interaction/sapi_entity_interaction.install
@@ -1,9 +1,0 @@
-<?php
-
-/**
- * Implements hook_uninstall().
- */
-function sapi_entity_interaction_uninstall() {
-  // Remove field_colors field on uninstall.
-  Drupal::configFactory()->getEditable('field.storage.node.field_colors')->delete();
-}

--- a/modules/sapi_entity_interaction/sapi_entity_interaction.module
+++ b/modules/sapi_entity_interaction/sapi_entity_interaction.module
@@ -1,0 +1,23 @@
+<?php
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_entity_update()
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function sapi_entity_interaction_entity_update(EntityInterface $entity){
+  \Drupal::service('sapi_entity_interaction.entity_interaction_collector')->actionTypeTrigger($entity,'Update');
+}
+
+/**
+ * Implements hook_entity_insert()
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function sapi_entity_interaction_entity_insert(EntityInterface $entity) {
+  if ($entity->getEntityTypeId() != 'sapi_data') {
+    \Drupal::service('sapi_entity_interaction.entity_interaction_collector')->actionTypeTrigger($entity,'Create');
+  }
+}

--- a/modules/sapi_entity_interaction/sapi_entity_interaction.services.yml
+++ b/modules/sapi_entity_interaction/sapi_entity_interaction.services.yml
@@ -1,0 +1,10 @@
+services:
+  sapi_entity_interaction.entity_view_event_subscriber:
+    class: Drupal\sapi_entity_interaction\EventSubscriber\EntityViewEventSubscriber
+    arguments: ["@current_user", "@sapi.dispatcher", "@plugin.manager.sapi_action_type", "@current_route_match"]
+    tags:
+      - { name: event_subscriber }
+  sapi_entity_interaction.entity_interaction_collector:
+    class: Drupal\sapi_entity_interaction\EntityInteractionCollector
+    arguments: ["@current_user", "@sapi.dispatcher", "@plugin.manager.sapi_action_type"]
+

--- a/modules/sapi_entity_interaction/src/EntityInteractionCollector.php
+++ b/modules/sapi_entity_interaction/src/EntityInteractionCollector.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\sapi_entity_interaction;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\sapi\ActionTypeInterface;
+use Drupal\sapi\Dispatcher;
+use Drupal\sapi\ActionTypeManager;
+use Drupal\Core\Entity;
+
+/**
+ * Class EntityInteractionCollector.
+ *
+ * @package Drupal\sapi_entity_interaction
+ */
+class EntityInteractionCollector {
+
+  /**
+   * Drupal\Core\Session\AccountProxy definition.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * Drupal\sapi\Dispatcher definition.
+   *
+   * @var \Drupal\sapi\Dispatcher
+   */
+  protected $sapiDispatcher;
+
+  /**
+   * Drupal\sapi\ActionTypeManager definition.
+   *
+   * @var \Drupal\sapi\ActionTypeManager
+   */
+  protected $sapiActionTypeManager;
+
+  /**
+   * EntityInteractionCollector constructor.
+   */
+  public function __construct(AccountProxy $currentUser, Dispatcher $sapiDispatcher, ActionTypeManager $sapiActionTypeManager) {
+    $this->currentUser = $currentUser;
+    $this->sapiDispatcher = $sapiDispatcher;
+    $this->sapiActionTypeManager = $sapiActionTypeManager;
+  }
+
+  /**
+   * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   * @param string $operation Type of operation made on entity.
+   */
+  function actionTypeTrigger(EntityInterface $entity, $operation){
+    try {
+      /** @var \Drupal\sapi\ActionTypeInterface $action */
+      $action = $this->sapiActionTypeManager->createInstance('entity_interaction', ['account'=> $this->currentUser,'entity'=> $entity,'action'=> $operation,'mode'=> '']);
+      if (!($action instanceof ActionTypeInterface)) {
+        throw new \Exception('No entity_interaction plugin was found');
+      }
+      $this->sapiDispatcher->dispatch($action);
+    } catch (\Exception $e) {
+      watchdog_exception('sapi_entity_interaction', $e);
+    }
+  }
+
+}

--- a/modules/sapi_entity_interaction/src/EventSubscriber/EntityViewEventSubscriber.php
+++ b/modules/sapi_entity_interaction/src/EventSubscriber/EntityViewEventSubscriber.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\sapi_entity_interaction\EventSubscriber;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\sapi\Dispatcher;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Drupal\sapi\ActionTypeInterface;
+use Drupal\Core\Entity;
+
+/**
+ * Class EntityViewEventSubscriber.
+ *
+ * @package Drupal\sapi_entity_interaction
+ */
+class EntityViewEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Drupal\Core\Session\AccountProxy definition.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * Drupal\sapi\Dispatcher definition.
+   *
+   * @var \Drupal\sapi\Dispatcher
+   */
+  protected $sapiDispatcher;
+
+  /**
+   * The statistics action type plugin manager which will be used to create sapi
+   * items to be passed to the dispatcher
+   *
+   * @var \Drupal\Component\Plugin\PluginManagerInterface $sapiActionTypeManager
+   */
+  protected $sapiActionTypeManager;
+
+  /**
+   * Drupal\Core\Routing\CurrentRouteMatch definition.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRouteMatch;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(AccountProxy $currentUser, Dispatcher $sapiDispatcher, PluginManagerInterface $sapiActionTypeManager, CurrentRouteMatch $currentRouteMatch) {
+    $this->currentUser = $currentUser;
+    $this->sapiDispatcher = $sapiDispatcher;
+    $this->sapiActionTypeManager = $sapiActionTypeManager;
+    $this->currentRouteMatch = $currentRouteMatch;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  static function getSubscribedEvents() {
+    // Priority is set to 1 to avoid this listener from being stopped by other
+    // listeners.
+    // @see ContainerAwareEventDispatcher::dispatch()
+    $events[KernelEvents::VIEW][] = ['onEventView', 1];
+    return $events;
+  }
+
+  /**
+   * Informs Statistics API dispatcher when controller outputs a value which is
+   * not a Response instance.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent $event
+   */
+  public function onEventView(Event $event) {
+    try {
+      if (preg_match('/entity\.([\w]+)\.canonical/',$this->currentRouteMatch->getRouteName(), $matches)) {
+        /** @var \Drupal\Core\Entity\EntityInterface $entity */
+        $entity = $this->currentRouteMatch->getParameter($matches[1]);
+        /** @var string $mode String containing Display mode. */
+        $mode = $event->getControllerResult()['#view_mode'];
+        /** @var \Drupal\sapi\ActionTypeInterface $action */
+        $action = $this->sapiActionTypeManager->createInstance('entity_interaction', ['account'=> $this->currentUser,'entity'=> $entity,'action'=> 'View','mode'=> $mode]);
+        if (!($action instanceof ActionTypeInterface)) {
+          throw new \Exception('No entity_interaction plugin was found');
+        }
+        $this->sapiDispatcher->dispatch($action);
+      }
+    } catch (\Exception $e) {
+      watchdog_exception('sapi_entity_interaction', $e);
+    }
+  }
+
+}

--- a/modules/sapi_entity_interaction/src/Plugin/Statistics/ActionHandler/EntityInteractionTracker.php
+++ b/modules/sapi_entity_interaction/src/Plugin/Statistics/ActionHandler/EntityInteractionTracker.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\sapi_entity_interaction\Plugin\Statistics\ActionHandler;
+
+use Drupal\sapi\ActionHandlerInterface;
+use Drupal\sapi\ActionHandlerBase;
+use Drupal\sapi\ActionTypeInterface;
+use Drupal\sapi\Plugin\Statistics\ActionType\EntityInteraction;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+
+/**
+ * This is a SAPI handler plugin used to track any entity interactions (view, update and create).
+ *
+ * @ActionHandler(
+ *  id = "entity_interaction_tracker",
+ *  label = "Track any entity interactions"
+ * )
+ */
+class EntityInteractionTracker extends ActionHandlerBase implements ActionHandlerInterface, ContainerFactoryPluginInterface{
+
+  /**
+   * EntityTypeManager used to get entity storage for sapi_data items, which is
+   * used to create and edit sapi_data items from tracking.
+   *
+   * @protected Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * EntityInteractionTracker constructor.
+   *
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entityTypeManager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process(ActionTypeInterface $action){
+
+    /**
+     * Only acts if $action is an EntityInteraction plugin type
+     */
+    if (!($action instanceof EntityInteraction)) {
+      return;
+    }
+
+    /**
+     * @var string $entity_type
+     *   Entity type ID
+     */
+    $entity_type = $action->getEntity()->getEntityTypeId();
+
+    /**
+     * @var string $entity_id
+     *   ID of Entity
+     */
+    $entity_id = $action->getEntity()->id();
+
+    /**
+     * @var string $interaction_type
+     *   Interaction type to Entity(View, Update, Create)
+     */
+    $interaction_type = $action->getAction();
+
+    /**
+     * @var string $user_id
+     *   UID of user who interacted to Entity
+     */
+    $user_id = $action->getAccount()->id();
+
+    /**
+     * @var EntityStorageInterface $sapiDataStorage
+     */
+    $sapiDataStorage = $this->entityTypeManager->getStorage('sapi_data');
+
+    /** Creating a new interaction entity */
+
+    /** @var \Drupal\sapi_data\SAPIDataInterface $sapiData */
+    $sapiData = $sapiDataStorage->create([
+      'type' => 'entity_interactions',
+      'name' => $entity_type .':'. $entity_id .':'. $interaction_type,
+      'field_interaction_type' => $interaction_type,
+      'field_entity_reference' => ['target_id'=>$entity_id, 'target_type'=>$entity_type],
+      'field_user' => $user_id,
+    ]);
+
+    if (!$sapiData->save()) {
+      \Drupal::logger('sapi')->warning('Could not create SAPI data');
+    }
+
+  }
+
+}


### PR DESCRIPTION
Added `sapi_entity_interaction` module which allows to track user interactions(view, update, create) to entities. This module comes from [Drupal sapi2 prototype demo](https://github.com/james-nesbitt/drupal-sapi2-prototype-demo) repo `sapi_demo` module. 

This module contains:
- composer.json with dependency on [Dynamic Entity Reference](https://www.drupal.org/project/dynamic_entity_reference) module
- Configuration files which creates:
  - entity_interaction bundle of `sapi_data` entity type
  - fields for `entity_interaction` bundle
  - different views and blocks, that allows admin and anonymous users see general statistics on entities interactions (See these Trello cards: https://trello.com/c/SHLNC8ix; https://trello.com/c/oYgjPqBS; https://trello.com/c/imcfTyKY; https://trello.com/c/XqsfNflt; https://trello.com/c/eOk0Di96; https://trello.com/c/6xZH15CR)

To make sure that this module work properly:
- enable it(It will ask to enable `sapi`, `sapi_data` and `dynamic_entity_reference` modules)
- enable `entity_interaction_tracker` handler plugin here - `/admin/config/sapi/statistics-plugins`
- create new article or page(You can also create new user, term and/or any other entity)
- view it, edit it couple of times
- in database tabel `sapi_data` You will be able see entries which indicated that interactions are collected.
- on Drupal sites first page you will see 2 blocks which show information about top 5 contributors(user, who created or updated any entity) and top viewed entities. 
